### PR TITLE
Escape string against shell command inject

### DIFF
--- a/Command.php
+++ b/Command.php
@@ -223,11 +223,11 @@ class Command
     /**
      * Escapes a string in order to inject it in the shell command.
      */
-    public function escape(string $string, bool $addQuotes = false): string
+    public function escape(string $string): string
     {
         $string = escapeshellarg($string);
 
-        return $addQuotes ? '"'.$string.'"' : $string;
+        return $string;
     }
 
     /**

--- a/Command.php
+++ b/Command.php
@@ -223,13 +223,9 @@ class Command
     /**
      * Escapes a string in order to inject it in the shell command.
      */
-    public function escape(string $string, bool $addQuotes = true): string
+    public function escape(string $string, bool $addQuotes = false): string
     {
-        $string = str_replace(
-            ['"', '`', '’', '\\\''],
-            ['\"', "'", "'", "'"],
-            trim($string)
-        );
+        $string = escapeshellarg($string);
 
         return $addQuotes ? '"'.$string.'"' : $string;
     }

--- a/Tests/CommandTest.php
+++ b/Tests/CommandTest.php
@@ -153,7 +153,7 @@ class CommandTest extends AbstractTestCase
 
         $expected = ' '.$command->getExecutable('convert').
                     ' "'.$source.'"'.
-                    ' -thumbnail "'.$geometry.'"'.
+                    ' -thumbnail \''.$geometry.'\''.
                     ' -quality '.$quality.
                     ' "'.$output.'" ';
 

--- a/Tests/CommandTest.php
+++ b/Tests/CommandTest.php
@@ -197,13 +197,13 @@ class CommandTest extends AbstractTestCase
 
     public function testEscape()
     {
-        $string = 'PSR\'s a great `code` style standard. ';
+        $string = '25% $(touch hacked) #';
 
         $command = new Command(IMAGEMAGICK_DIR);
 
-        $escaped = $command->escape($string, true);
+        $escaped = $command->escape($string);
 
-        $this->assertEquals('"PSR\'s a great \'code\' style standard."', $escaped);
+        $this->assertEquals("'25% $(touch hacked) #'", $escaped);
     }
 
 }


### PR DESCRIPTION
Using escapeshellarg() instead escape hard filter.

Here is the test.

![screenshot from 2019-01-17 07-14-40](https://user-images.githubusercontent.com/26088039/51285415-b427cf80-1a29-11e9-9c65-32c3a84d5c14.png)

```php
<?php

function escape($string,$addQuotes = true)
{
        $string = str_replace(
            ['"', '`', '’', '\\\''],
            ['\"', "'", "'", "'"],
            trim($string)
        );
        return $addQuotes ? '"'.$string.'"' : $string;
}

function escape_safe($string,$addQuotes = false)
{
 		$string = escapeshellarg($string);
        return $addQuotes ? '"'.$string.'"' : $string;
}

$cmd = '$(uname -a)';

$escape_cmd = escape($cmd);
$command = "/usr/bin/convert logo.png -resize " . $escape_cmd . " result.png";
echo $command . PHP_EOL;
echo exec($command);

echo "\n\n";

$escape_cmd = escape_safe($cmd);
$command = "/usr/bin/convert logo.png -resize " . $escape_cmd . " result.png";
echo $command . PHP_EOL;
echo exec($command);
```
