### PR TITLE
Typo in blur method of Reference.php fixed, from float changed to string

### DIFF
--- a/References.php
+++ b/References.php
@@ -184,7 +184,7 @@ final class References
         ));
     }
 
-    public function blur(string $blur): float
+    public function blur(string $blur): string
     {
         $blur = \trim($blur);
 


### PR DESCRIPTION
(note added by @Pierstoval : Fixes #22 ) 