### PR TITLE
Don't call trigger_error with E_STRICT

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -672,7 +672,7 @@ If you are certain of what you are doing, you can silence this error using the "
 If the option you need is not supported, please open an issue or a pull-request at https://github.com/Orbitale/ImageMagickPHP in order for us to implement the option you need! 😃
 MSG
 ;
-        @\trigger_error($msg, \E_USER_NOTICE);
+        @\trigger_error($msg, \E_USER_WARNING);
 
         if ($append) {
             $this->commandToAppend[] = $command;

--- a/src/Command.php
+++ b/src/Command.php
@@ -672,7 +672,7 @@ If you are certain of what you are doing, you can silence this error using the "
 If the option you need is not supported, please open an issue or a pull-request at https://github.com/Orbitale/ImageMagickPHP in order for us to implement the option you need! 😃
 MSG
 ;
-        @\trigger_error($msg, \E_STRICT);
+        @\trigger_error($msg, \E_USER_NOTICE);
 
         if ($append) {
             $this->commandToAppend[] = $command;


### PR DESCRIPTION
In Php 8, using E_STRICT with trigger_error throws a value error, which was a warning in Php 7.
The warning was silenced with the @ operator, which isn't possible with the value error.

* https://3v4l.org/gSMPj
* https://3v4l.org/5PWAr